### PR TITLE
Fix SparkWebContext getFullRequestURL to include the client queryString

### DIFF
--- a/src/main/java/org/pac4j/sparkjava/SparkWebContext.java
+++ b/src/main/java/org/pac4j/sparkjava/SparkWebContext.java
@@ -116,7 +116,14 @@ public class SparkWebContext implements WebContext {
 
 	@Override
 	public String getFullRequestURL() {
-		return request.url();
+		StringBuilder requestURL = new StringBuilder(request.url());
+		String queryString = request.queryString();
+		if (queryString == null) {
+			return requestURL.toString();
+		}
+		else {
+			return requestURL.append('?').append(queryString).toString();
+		}
 	}
 
 	public String getBody() {


### PR DESCRIPTION
Here it is the fix for the issue discussed here: https://github.com/pac4j/spark-pac4j/issues/4.
I will be able to test with my project.
Thanks!