### PR TITLE
Extended DefaultHttpActionAdapter for supporting individual/ multiple…

### DIFF
--- a/src/main/java/org/pac4j/sparkjava/DefaultHttpActionAdapter.java
+++ b/src/main/java/org/pac4j/sparkjava/DefaultHttpActionAdapter.java
@@ -5,30 +5,52 @@ import org.pac4j.core.http.HttpActionAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static spark.Spark.halt;
+import spark.Service;
+import spark.Spark;
 
 /**
  * Default HTTP action adapter.
  *
  * @author Jerome Leleu
+ * @author Marco Günther
  * @since 1.1.0
  */
 public class DefaultHttpActionAdapter implements HttpActionAdapter<Object, SparkWebContext> {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
+    
+    protected Service service;
 
-    @Override
+    public DefaultHttpActionAdapter() {
+		super();
+	}
+
+	public DefaultHttpActionAdapter(Service service) {
+		this.service = service;
+	}
+
+	@Override
     public Object adapt(int code, SparkWebContext context) {
         logger.debug("requires HTTP action: {}", code);
         if (code == HttpConstants.UNAUTHORIZED) {
-            halt(HttpConstants.UNAUTHORIZED, "authentication required");
+            halt(HttpConstants.UNAUTHORIZED, "authentication required", context);
         } else if (code == HttpConstants.FORBIDDEN) {
-            halt(HttpConstants.FORBIDDEN, "forbidden");
+            halt(HttpConstants.FORBIDDEN, "forbidden", context);
         } else if (code == HttpConstants.OK) {
-            halt(HttpConstants.OK, context.getSparkResponse().body());
+            halt(HttpConstants.OK, context.getSparkResponse().body(), context);
         } else if (code == HttpConstants.TEMP_REDIRECT) {
             context.getSparkResponse().redirect(context.getLocation());
         }
         return null;
     }
+
+	protected void halt(int status, String body, SparkWebContext context) {
+		context.setResponseHeader("content-type", "text/plain");
+		if (service == null) {
+			Spark.halt(status, body);
+		} else {
+			service.halt(status, body);
+		}
+	}
+
 }


### PR DESCRIPTION
… service ignitions, by keeping backward compatibility

Example:

    public static void main(String[] args) {
     	final Service service = Service.ignite().port(PORT).threadPool(20);
        final Config securityConfig = createSecurityConfiguration(AUTH0_SALT, service);
	service.before("/products", new SecurityFilter(securityConfig, AUTH0));
	service.get("/products", (req, res) ->
	    new ProductsRequestHandler().getProducts(), new JsonTransformer());

        final Service actuator = Service.ignite().port(PORT+1).threadPool(10);
        actuator.get("/health", (req, res) ->
            Status.UP, new JsonTransformer());

    }

    public static Config createSecurityConfiguration(final String salt, final Service service) {
        final HeaderClient headerClient = new HeaderClient("Authorization", "Bearer ", new JwtAuthenticator(new SecretSignatureConfiguration(salt)));
        headerClient.setName(AUTH0);

        final Config config = new Config(new Clients(headerClient));
        config.setHttpActionAdapter(new **DefaultHttpActionAdapter(service)**);
        return config;
    }