### PR TITLE
More efficient grant access implementation

### DIFF
--- a/src/main/java/org/pac4j/sparkjava/SecurityFilter.java
+++ b/src/main/java/org/pac4j/sparkjava/SecurityFilter.java
@@ -65,17 +65,16 @@ public class SecurityFilter implements Filter {
         assertNotNull("securityLogic", securityLogic);
         assertNotNull("config", config);
         final SparkWebContext context = new SparkWebContext(request, response, config.getSessionStore());
-
-        try {
-            securityLogic.perform(context, this.config, (ctx, parameters) -> {
-                throw new SecurityGrantedAccessException();
-            }, config.getHttpActionAdapter(), this.clients, this.authorizers, this.matchers, this.multiProfile);
+        final Object result = securityLogic.perform(context, this.config,
+                (ctx, parameters) -> SecurityGrantedAccess.INSTANCE, config.getHttpActionAdapter(),
+                this.clients, this.authorizers, this.matchers, this.multiProfile);
+        if (result == SecurityGrantedAccess.INSTANCE) {
+            // It means that the access is granted: continue
+            logger.debug("Received SecurityGrantedAccessException -> continue");
+        } else {
             logger.debug("Halt the request processing");
             // stop the processing if no success granted access exception has been raised
             halt();
-        } catch (final SecurityGrantedAccessException e) {
-            // ignore this exception, it meants the access is granted: continue
-            logger.debug("Received SecurityGrantedAccessException -> continue");
         }
     }
 

--- a/src/main/java/org/pac4j/sparkjava/SecurityGrantedAccess.java
+++ b/src/main/java/org/pac4j/sparkjava/SecurityGrantedAccess.java
@@ -1,0 +1,18 @@
+package org.pac4j.sparkjava;
+
+/**
+ * The marker singleton object as a signal that the access is granted.
+ */
+final class SecurityGrantedAccess {
+    
+    /**
+     * The only instance.
+     */
+    static final SecurityGrantedAccess INSTANCE = new SecurityGrantedAccess();
+    
+    /**
+     * Enforce singleton
+     */
+    private SecurityGrantedAccess() {}
+    
+}


### PR DESCRIPTION
I raised the issue of the usage of exception to grant access [here](https://github.com/pac4j/spark-pac4j/issues/28). I think exceptions are costly and should be avoided to indicate some positive things.

In this pull request, I used the SecurityGrantedAccess singleton as the return value of lambda to indicate access is granted. This class is package private so others will not use it in unexpected ways.
Checking whether access is granted is done by checking referential equality to the singleton of the result from the securityLogic.

I also kept the original SecurityGrantedAccessException since it's public and may already used by others.
